### PR TITLE
security: enforce restricted pod security policy in namespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ target/
 /k8s/output
 k8s/patch.yaml
 /.rules
+/CLAUDE.md

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -4,4 +4,4 @@ metadata:
   name: simple-budget
   labels:
     name: simple-budget
-    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/enforce: restricted

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -5,3 +5,5 @@ metadata:
   labels:
     name: simple-budget
     pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted


### PR DESCRIPTION
Changed pod-security label from 'warn' to 'enforce' to actively prevent pods that don't comply with restricted security standards from being scheduled in the simple-budget namespace.